### PR TITLE
#171182875 Hide hotels/rooms fields for locations without hotels

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17750,9 +17750,9 @@
       }
     },
     "wait-for-expect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.1.tgz",
-      "integrity": "sha512-3Ha7lu+zshEG/CeHdcpmQsZnnZpPj/UsG3DuKO8FskjuDbkx3jE3845H+CuwZjA2YWYDfKMU2KhnCaXMLd3wVw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-3.0.2.tgz",
+      "integrity": "sha512-cfS1+DZxuav1aBYbaO/kE06EOS8yRw7qOFoD3XtjTkYvCvh3zUvNST8DXK/nPaeqIzIv3P3kL3lRJn8iwOiSag==",
       "dev": true
     },
     "walker": {

--- a/package.json
+++ b/package.json
@@ -75,12 +75,12 @@
     "sass": "^1.24.0",
     "sass-loader": "^8.0.0",
     "style-loader": "^1.1.1",
+    "terser-webpack-plugin": "^2.3.3",
     "url-loader": "^3.0.0",
     "webpack": "^4.41.4",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.10.1",
     "webpack-hot-middleware": "^2.25.0",
-    "terser-webpack-plugin": "^2.3.3",
     "webpack-merge": "^4.2.2"
   },
   "dependencies": {

--- a/src/__tests__/actions/createTripActions.spec.js
+++ b/src/__tests__/actions/createTripActions.spec.js
@@ -1,0 +1,61 @@
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import moxios from 'moxios';
+import { FETCH_CREATE_TRIP_DATA_FAILURE } from '../../store/actions/types';
+import { fetchCreateTripData } from '../../store/actions/requests/createTripActions';
+import apiCall from '../../utils/api';
+import localStorage from "../../__mocks__/LocalStorage";
+
+let store;
+const middlewares = [thunk];
+const mockStore = configureMockStore(middlewares);
+
+describe('Create Trip Test Suite', () => {
+  beforeAll(() => {
+    global.localStorage = localStorage;
+    global.localStorage.setItem("bn_user_data", `{
+      "email":"requestero@user.com",
+      "name":"Requester",
+      "userId":2,
+      "verified":true,
+      "role":"requester",
+      "lineManagerId":7,
+      "iat":1578472431,
+      "exp":1578558831
+    }`);
+  });
+  beforeEach(() => {
+    moxios.install(apiCall);
+  });
+
+  afterEach(() => {
+    moxios.uninstall(apiCall);
+  });
+
+  it('It fails to fetch create trip data', async () => {
+    moxios.wait(() => {
+      const request = moxios.requests.mostRecent();
+      request.respondWith({
+        response: {
+          "status": "error",
+          "message": "failed to fetch create trip data"
+        },
+        status: 400
+      });
+    });
+
+    const expectedActions = [
+      {
+        payload: "failed to fetch create trip data",
+        type: FETCH_CREATE_TRIP_DATA_FAILURE,
+      }
+    ];
+
+    store = mockStore({});
+    await store.dispatch(fetchCreateTripData())
+    .then(async () => {
+      const calledActions = store.getActions();
+      expect(calledActions).toEqual(expectedActions);
+    });
+  });
+});

--- a/src/__tests__/components/request/CreateRequest.spec.js
+++ b/src/__tests__/components/request/CreateRequest.spec.js
@@ -456,6 +456,44 @@ describe(' ', () => {
 
   });
 
+  test('User can create one way trip without updating profile', async () => {
+    getLocations.mockImplementation(() => Promise.resolve(locations));
+    getLocationsWithHotels.mockImplementation(() => Promise.resolve(locationWithHotels));
+    createATrip.mockImplementation(() => Promise.resolve(responseData));
+    getUserRatingData.mockImplementation(() => Promise.resolve(ratingDataResponse));
+    getBookingData.mockImplementation(() => Promise.resolve(bookingDataResponse));
+
+    const initialState = {
+      authState: {
+        isAuthenticated: true
+      }
+    };
+    const { getByTestId } = render(<BrowserRouter><CreateRequestPage /></BrowserRouter>, initialState);
+
+    const [
+      oneWayTypeField,
+      travelDateField,
+      leavingFromField,
+      goingToField,
+      reasonField,
+      submitButton
+    ] = await waitForElement(() => [
+      getByTestId('oneway'),
+      getByTestId('travelDate'),
+      getByTestId('leavingFrom'),
+      getByTestId('goingTo'),
+      getByTestId('reason'),
+      getByTestId('submitInput'),
+    ]);
+
+    fireEvent.click(oneWayTypeField);
+    fireEvent.change(travelDateField, {target:{value: '2020-03-01'}});
+    fireEvent.change(leavingFromField, {target:{value: 1}});
+    fireEvent.change(goingToField, {target:{value: 7}});
+    fireEvent.change(reasonField, {target:{value: 'Reason for the trip goes here'}});
+		fireEvent.click(submitButton);
+  });
+
   test('User can create a return trip', async () => {
     getLocations.mockImplementation(() => Promise.resolve(locations));
     getLocationsWithHotels.mockImplementation(() => Promise.resolve(locationWithHotels));
@@ -507,6 +545,58 @@ describe(' ', () => {
 
   });
 
+
+  test('User can clear date validation error after correcting return trip dates', async () => {
+    getLocations.mockImplementation(() => Promise.resolve(locations));
+    getLocationsWithHotels.mockImplementation(() => Promise.resolve(locationWithHotels));
+    createATrip.mockImplementation(() => Promise.resolve(responseData));
+		getUserProfile.mockImplementation(() => Promise.resolve(userProfile));
+    getUsers.mockImplementation(() => Promise.resolve(managers));
+    getUserRatingData.mockImplementation(() => Promise.resolve(ratingDataResponse));
+    getBookingData.mockImplementation(() => Promise.resolve(bookingDataResponse));
+
+
+		const initialState = {
+      authState: {
+        isAuthenticated: true
+      }
+    };
+    const { getByTestId } = render(<BrowserRouter><CreateRequestPage /></BrowserRouter>, initialState);
+
+    const [
+      returnTypeField,
+      travelDateField,
+      returnDateField,
+      leavingFromField,
+      goingToField,
+      selectHotelField,
+      selectRoomField,
+      reasonField,
+      submitButton
+    ] = await waitForElement(() => [
+      getByTestId('return'),
+      getByTestId('travelDate'),
+      getByTestId('returnDate'),
+      getByTestId('leavingFrom'),
+      getByTestId('goingTo'),
+      getByTestId('hotel'),
+      getByTestId('room'),
+      getByTestId('reason'),
+      getByTestId('submitInput'),
+    ]);
+
+    fireEvent.click(returnTypeField);
+    fireEvent.change(returnDateField, {target:{value: '2020-03-31'}});
+    fireEvent.change(travelDateField, {target:{value: '2021-01-31'}});
+    fireEvent.change(leavingFromField, {target:{value: 1}});
+    fireEvent.change(goingToField, {target:{value: 7}});
+    fireEvent.change(selectHotelField, {target:{value: 1}});
+    fireEvent.change(selectRoomField, {target:{value: 9}});
+    fireEvent.change(reasonField, {target:{value: 'Reason for the trip goes here'}});
+    fireEvent.click(submitButton);
+    fireEvent.change(returnDateField, {target:{value: '2021-03-31'}});
+    fireEvent.click(submitButton);
+  });
 
   test('User can create a multi-city trip', async () => {
     getLocations.mockImplementation(() => Promise.resolve(locations));
@@ -623,40 +713,93 @@ describe(' ', () => {
     fireEvent.click(removeButton[1])
 
   });
-})
 
-describe(' ', () => {
-  beforeAll(() => {
-    global.localStorage.setItem("bn_user_data", `{
-      "email":"requestero@user.com",
-      "name":"Requester",
-      "userId":2,
-      "verified":true,
-      "role":"requester",
-      "lineManagerId": null,
-      "iat":1578472431,
-      "exp":1578558831
-    }`);
-  })
-
-  afterEach(() => {
-    cleanup();
-    global.localStorage.clear();
-    localStorage.store = {};
-   });
+  test('Prevent goingTo from being set to null on form delete', async () => {
+    getLocations.mockImplementation(() => Promise.resolve(locations));
+    getLocationsWithHotels.mockImplementation(() => Promise.resolve(locationWithHotels));
+    createATrip.mockImplementation(() => Promise.resolve(responseData));
+		getUserProfile.mockImplementation(() => Promise.resolve(userProfile));
+    getUsers.mockImplementation(() => Promise.resolve(managers));
+    getUserRatingData.mockImplementation(() => Promise.resolve(ratingDataResponse));
+    getBookingData.mockImplementation(() => Promise.resolve(bookingDataResponse));
 
 
-  //  test('User can create a one way trip', async () => {
-  //   getLocations.mockImplementation(() => Promise.resolve(locations));
-  //   getLocationsWithHotels.mockImplementation(() => Promise.resolve(locationWithHotels));
-  //   createATrip.mockImplementation(() => Promise.resolve(responseData));
-	//
-  //   const initialState = {
-  //     authState: {
-  //       isAuthenticated: true
-  //     }
-  //   };
-  //   const { getByTestId } = render(<BrowserRouter><CreateRequestPage /></BrowserRouter>, initialState);
-	//
-  // });
+    const initialState = {
+      authState: {
+        isAuthenticated: true
+      }
+    };
+    const { getByTestId ,getAllByTestId } = render(<BrowserRouter><CreateRequestPage /></BrowserRouter>, initialState);
+
+    const [
+      multiCityTypeField,
+      travelDateField,
+      leavingFromField,
+      goingToField,
+      selectHotelField,
+      selectRoomField,
+      reasonField,
+      submitButton,
+      addTripButton,
+    ] = await waitForElement(() => [
+      getAllByTestId('multi-city'),
+      getAllByTestId('travelDate'),
+      getAllByTestId('leavingFrom'),
+      getAllByTestId('goingTo'),
+      getAllByTestId('hotel'),
+      getAllByTestId('room'),
+      getAllByTestId('reason'),
+      getByTestId('submitInput'),
+      getByTestId('addbutton'),
+    ]);
+
+    fireEvent.click(multiCityTypeField[0]);
+
+
+    fireEvent.click(addTripButton);
+    fireEvent.click(addTripButton);
+
+    const [
+      travelDateField1,
+      leavingFromField1,
+      goingToField1,
+      selectHotelField1,
+      selectRoomField1,
+      reasonField1,
+      addTripButton1,
+      multiCityTypeField1,
+    ] = await waitForElement(() => [
+      getAllByTestId('travelDate'),
+      getAllByTestId('leavingFrom'),
+      getAllByTestId('goingTo'),
+      getAllByTestId('hotel'),
+      getAllByTestId('room'),
+      getAllByTestId('reason'),
+      getByTestId('addbutton'),
+      getAllByTestId('multi-city'),
+    ]);
+
+    fireEvent.change(travelDateField[0], {target:{value: '2021-01-31'}});
+    fireEvent.change(leavingFromField[0], {target:{value: 1}});
+    fireEvent.change(goingToField[0], {target:{value: 7}});
+    fireEvent.change(selectHotelField[0], {target:{value: 1}});
+    fireEvent.change(selectRoomField[0], {target:{value: 9}});
+    fireEvent.change(reasonField[0], {target:{value: 'Reason for the trip goes here'}});
+
+    fireEvent.change(travelDateField1[1], {target:{value: '2021-01-31'}});
+    fireEvent.change(leavingFromField1[1], {target:{value: 1}});
+    fireEvent.change(goingToField1[1], {target:{value: 7}});
+    fireEvent.change(reasonField1[1], {target:{value: 'Reason for the trip goes here'}});
+
+
+    const [
+      removeBtns,
+    ] = await waitForElement(() => [
+      getAllByTestId('delete'),
+    ]);
+
+    fireEvent.click(removeBtns[1]);
+
   });
+
+})

--- a/src/components/ProtectedRoute.js
+++ b/src/components/ProtectedRoute.js
@@ -54,7 +54,7 @@ export const ProtectedRoute = ({
 };
 
 ProtectedRoute.propTypes = {
-	component: PropTypes.object,
+	component: PropTypes.any,
 	location: PropTypes.shape({ pathname: PropTypes.string.isRequired }),
 	setAuthState: PropTypes.func.isRequired,
 };


### PR DESCRIPTION
#### What does this PR do?
This PR updates the create trip request page so that the hotels and rooms select fields are only displayed if a location has them available

#### Description of Task to be completed?
- [x] add Refs to various input fields
- [x] conditionally render some select fields based on user's options for destination location
- [x] add extra validations on creating a trip
- [x] fix console errors appearing on our App

#### How should this be manually tested?
- git clone this repo
- navigate to the project folder using Terminal
- install dependencies using `npm install`
- run tests using `npm test`
- open the App in the browser using `npm run watch`
- test the update to create a trip request
  - set the destination to a location without hotels and the hotel and rooms fields will not be rendered, they will only be rendered for locations with hotels

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
[#171182875](https://www.pivotaltracker.com/story/show/171182875)

#### Screenshots (if appropriate)
<img width="1436" alt="Screen Shot 2020-02-11 at 14 43 30" src="https://user-images.githubusercontent.com/17108099/74238001-799c6f00-4cdd-11ea-8231-0e1e2748ac15.png">
<img width="1439" alt="Screen Shot 2020-02-11 at 14 44 11" src="https://user-images.githubusercontent.com/17108099/74238015-8325d700-4cdd-11ea-8b7f-4d24190a51b4.png">

#### Questions:
N/A
